### PR TITLE
添加 gotify 的 https 支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ ops = Login,NewProxy,NewWorkConn,NewUserConn       // 通知的操作
     {
       "name": "gotify",                                                                // 固定配置
       "config": {
+        "server_proto": "http",                                                        // gotify-server 上报协议
         "server_addr": "127.0.0.1:40080",                                              // gotify-server 服务地址
         "app_token": "token"                                                           // gotify-server 配置的 app token
       }

--- a/conf/frp-notify.json
+++ b/conf/frp-notify.json
@@ -7,6 +7,7 @@
     {
       "name": "gotify",
       "config": {
+        "server_proto": "http",
         "server_addr": "127.0.0.1:80",
         "app_token": "AXE9tspWxFgasBC"
       }

--- a/pkg/config/notify.go
+++ b/pkg/config/notify.go
@@ -22,8 +22,9 @@ type NotifyConfig struct {
 
 // GotifyConfig gotify configuration
 type GotifyConfig struct {
-	ServerAddr string `json:"server_addr"`
-	AppToken   string `json:"app_token"`
+	ServerProto string `json:"server_proto"`
+	ServerAddr  string `json:"server_addr"`
+	AppToken    string `json:"app_token"`
 }
 
 // DingTalkConfig dingTalk configuration

--- a/pkg/notify/gotify/gotify.go
+++ b/pkg/notify/gotify/gotify.go
@@ -66,6 +66,10 @@ func parseAndVerifyConfig(cfg map[string]interface{}) (config config.GotifyConfi
 	if err != nil {
 		return
 	}
+	if config.ServerProto == "" {
+		config.ServerProto = "http"
+		log.Debugf("use default http protocol")
+	}
 	if config.ServerAddr == "" {
 		return config, fmt.Errorf("miss server_addr")
 	}

--- a/pkg/notify/gotify/gotify.go
+++ b/pkg/notify/gotify/gotify.go
@@ -48,9 +48,10 @@ func (g *gotifyNotify) SendMessage(title string, message string) {
 
 	_, err := g.client.R().
 		SetFormData(format).
-		Post(fmt.Sprintf("http://%s/message?token=%s", g.cfg.ServerAddr, g.cfg.AppToken))
+		Post(fmt.Sprintf("%s://%s/message?token=%s", g.cfg.ServerProto, g.cfg.ServerAddr, g.cfg.AppToken))
 	if err != nil {
-		log.Errorf("send message to gotify error, err: %s serverAddr: %s, token: %s", err, g.cfg.ServerAddr, g.cfg.AppToken)
+		log.Errorf("send message to gotify error, err: %s serverProto: %s, serverAddr: %s, token: %s", err,
+			g.cfg.ServerProto, g.cfg.ServerAddr, g.cfg.AppToken)
 	}
 }
 

--- a/pkg/notify/gotify/gotify_test.go
+++ b/pkg/notify/gotify/gotify_test.go
@@ -51,7 +51,9 @@ func Test_parseAndVerifyConfig(t *testing.T) {
 			args{
 				cfg: map[string]interface{}{},
 			},
-			config.GotifyConfig{},
+			config.GotifyConfig{
+				ServerProto: "http",
+			},
 			true,
 		},
 		{
@@ -59,7 +61,9 @@ func Test_parseAndVerifyConfig(t *testing.T) {
 			args{
 				cfg: map[string]interface{}{},
 			},
-			config.GotifyConfig{},
+			config.GotifyConfig{
+				ServerProto: "http",
+			},
 			true,
 		},
 		{
@@ -70,7 +74,8 @@ func Test_parseAndVerifyConfig(t *testing.T) {
 				},
 			},
 			config.GotifyConfig{
-				ServerAddr: "addr",
+				ServerProto: "http",
+				ServerAddr:  "addr",
 			},
 			true,
 		},

--- a/pkg/notify/gotify/gotify_test.go
+++ b/pkg/notify/gotify/gotify_test.go
@@ -34,15 +34,25 @@ func Test_parseAndVerifyConfig(t *testing.T) {
 			"normal",
 			args{
 				cfg: map[string]interface{}{
-					"server_addr": "addr",
-					"app_token":   "token",
+					"server_proto": "proto",
+					"server_addr":  "addr",
+					"app_token":    "token",
 				},
 			},
 			config.GotifyConfig{
-				ServerAddr: "addr",
-				AppToken:   "token",
+				ServerProto: "proto",
+				ServerAddr:  "addr",
+				AppToken:    "token",
 			},
 			false,
+		},
+		{
+			"miss server_proto",
+			args{
+				cfg: map[string]interface{}{},
+			},
+			config.GotifyConfig{},
+			true,
 		},
 		{
 			"miss server_addr",


### PR DESCRIPTION
gotify 同时支持 http 和 https ，所以在配置文件中添加协议的配置项，经测试工作正常。