### PR TITLE
fix(address_query): add new IP address query service provider and rel…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.18
 
 require (
 	github.com/JetBlink/dingtalk-notify-go-sdk v0.0.0-20191112085213-0dc836cea13e
-	github.com/axgle/mahonia v0.0.0-20180208002826-3358181d7394
 	github.com/go-resty/resty/v2 v2.2.0
 	github.com/sirupsen/logrus v1.5.0
+	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli v1.22.4
 	github.com/xen0n/go-workwx v1.0.1
 	istio.io/pkg v0.0.0-20201005190955-35c5fdf11bac
@@ -16,11 +16,12 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
-	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/net v0.0.0-20200222125558-5a598a2470a0 // indirect
 	golang.org/x/sys v0.0.0-20200116001909-b77594299b42 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/axgle/mahonia v0.0.0-20180208002826-3358181d7394 h1:OYA+5W64v3OgClL+IrOD63t4i/RW7RqrAVl9LTZ9UqQ=
-github.com/axgle/mahonia v0.0.0-20180208002826-3358181d7394/go.mod h1:Q8n74mJTIgjX4RBBcHnJ05h//6/k6foqmgE45jTQtxg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/pkg/ip/baidu_ip_addr_api.go
+++ b/pkg/ip/baidu_ip_addr_api.go
@@ -14,8 +14,8 @@ type BaiduIPAddrData struct {
 	DispType         int    `json:"disp_type,omitempty"`
 	FetchKey         string `json:"fetchkey,omitempty"`
 	Location         string `json:"location"`
-	OrigIp           string `json:"origip,omitempty"`
-	OrigIpQuery      string `json:"origipquery,omitempty"`
+	OrigIP           string `json:"origip,omitempty"`
+	OrigIPQuery      string `json:"origipquery,omitempty"`
 	ResourceID       string `json:"resourceid,omitempty"`
 	RoleID           int    `json:"role_id,omitempty"`
 	ShareImage       int    `json:"shareImage,omitempty"`

--- a/pkg/ip/baidu_ip_addr_api.go
+++ b/pkg/ip/baidu_ip_addr_api.go
@@ -1,0 +1,26 @@
+package ip
+
+type BaiduIPAddrResponse struct {
+	Status       string            `json:"status"`
+	T            string            `json:"t,omitempty"`
+	SetCacheTime string            `json:"set_cache_time,omitempty"`
+	Data         []BaiduIPAddrData `json:"data"`
+}
+
+type BaiduIPAddrData struct {
+	ExtendedLocation string `json:"ExtendedLocation,omitempty"`
+	OriginQuery      string `json:"OriginQuery,omitempty"`
+	AppInfo          string `json:"appinfo,omitempty"`
+	DispType         int    `json:"disp_type,omitempty"`
+	FetchKey         string `json:"fetchkey,omitempty"`
+	Location         string `json:"location"`
+	OrigIp           string `json:"origip,omitempty"`
+	OrigIpQuery      string `json:"origipquery,omitempty"`
+	ResourceID       string `json:"resourceid,omitempty"`
+	RoleID           int    `json:"role_id,omitempty"`
+	ShareImage       int    `json:"shareImage,omitempty"`
+	ShowLikeShare    int    `json:"showLikeShare,omitempty"`
+	ShowLamp         string `json:"showlamp,omitempty"`
+	TitleCont        string `json:"titlecont,omitempty"`
+	Tplt             string `json:"tplt,omitempty"`
+}

--- a/pkg/ip/baidu_ip_addr_api_test.go
+++ b/pkg/ip/baidu_ip_addr_api_test.go
@@ -1,0 +1,84 @@
+package ip
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaiduIpAddrUnmarshal(t *testing.T) {
+	jsonString := `{
+        "status": "0",
+        "t": "",
+        "set_cache_time": "",
+        "data": [
+            {
+                "ExtendedLocation": "",
+                "OriginQuery": "223.239.128.138",
+                "appinfo": "",
+                "disp_type": 0,
+                "fetchkey": "223.239.128.138",
+                "location": "India",
+                "origip": "223.239.128.138",
+                "origipquery": "223.239.128.138",
+                "resourceid": "6006",
+                "role_id": 0,
+                "shareImage": 1,
+                "showLikeShare": 1,
+                "showlamp": "1",
+                "titlecont": "IP Address Query",
+                "tplt": "ip"
+            }
+        ]
+    }`
+
+	var response BaiduIPAddrResponse
+	err := json.Unmarshal([]byte(jsonString), &response)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Printf("%+v\n", response)
+	t.Logf("ip address: %s", response.Data[0].OrigIpQuery)
+	t.Logf("ip location: %s", response.Data[0].Location)
+	assert.Equal(t, "223.239.128.138", response.Data[0].OrigIpQuery)
+	assert.Equal(t, "India", response.Data[0].Location)
+}
+
+func TestBaiduIpAddrUnmarshalWithEmptyData(t *testing.T) {
+	jsonString := `{
+        "status": "0",
+        "t": "",
+        "set_cache_time": "",
+        "data": []
+    }`
+
+	var response BaiduIPAddrResponse
+	err := json.Unmarshal([]byte(jsonString), &response)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	fmt.Printf("%+v\n", response)
+	assert.Equal(t, len(response.Data), 0)
+}
+
+func TestBaiduIpAddrUnmarshalWithMissingData(t *testing.T) {
+	jsonString := `{
+        "status": "0",
+        "t": "",
+        "set_cache_time": ""
+    }`
+
+	var response BaiduIPAddrResponse
+	err := json.Unmarshal([]byte(jsonString), &response)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	fmt.Printf("%+v\n", response)
+	assert.Equal(t, len(response.Data), 0)
+}

--- a/pkg/ip/baidu_ip_addr_api_test.go
+++ b/pkg/ip/baidu_ip_addr_api_test.go
@@ -42,9 +42,9 @@ func TestBaiduIpAddrUnmarshal(t *testing.T) {
 	}
 
 	fmt.Printf("%+v\n", response)
-	t.Logf("ip address: %s", response.Data[0].OrigIpQuery)
+	t.Logf("ip address: %s", response.Data[0].OrigIPQuery)
 	t.Logf("ip location: %s", response.Data[0].Location)
-	assert.Equal(t, "223.239.128.138", response.Data[0].OrigIpQuery)
+	assert.Equal(t, "223.239.128.138", response.Data[0].OrigIPQuery)
 	assert.Equal(t, "India", response.Data[0].Location)
 }
 

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -1,0 +1,16 @@
+package ip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDefaultAddressService(t *testing.T) {
+	as := NewDefaultAddressService()
+	ip := "128.199.146.208"
+	res := as.Query(ip)
+	assert.NotEmpty(t, res)
+	fmt.Printf("%s: %s\n", ip, res)
+}


### PR DESCRIPTION
fix 126 address query service error: no such host 

```
frp-notify[1184864]: level=error msg="ip query error, err: Get \"http://ip.ws.126.net/ipquery?ip=128.xxx.xxx.208\": dial tcp: lookup ip.ws.126.net on 127.0.0.53:53: no such host"
```
(The IP address in the above log has been processed)